### PR TITLE
Fix: Paths to sourcemaps containing spaces were not being resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.2
+
+* Fix: Paths to sourcemaps containing spaces were not being resolved
+
 ## 0.4.1
 
 * Add module field to package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-sourcemaps",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Rollup plugin for grabbing source maps from sourceMappingURLs",
   "author": "Max Davidson <davidsonmax@gmail.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,17 @@ import { createFilter } from 'rollup-pluginutils';
 import { resolve as resolveSourceMap } from 'source-map-resolve';
 import { readFile } from 'fs';
 
+// resolveSourceMap will url-escape paths containing spaces, which will make
+// readFile fail to locate files. So we need to unescape paths before passing
+// them to readFile.
+function readFileProxy(...args) {
+  if (args.length) {
+    // eslint-disable-next-line no-param-reassign
+    args[0] = unescape(args[0]);
+  }
+  return readFile(...args);
+}
+
 export default function sourcemaps({ include, exclude } = {}) {
   const filter = createFilter(include, exclude);
 
@@ -19,7 +30,7 @@ export default function sourcemaps({ include, exclude } = {}) {
             // Failed reading file, let the next plugin deal with it
             resolve(null);
           } else {
-            resolveSourceMap(code, id, readFile, (err, sourceMap) => {
+            resolveSourceMap(code, id, readFileProxy, (err, sourceMap) => {
               if (err || sourceMap === null) {
                 // Either something went wrong, or there was no source map
                 resolve(code);


### PR DESCRIPTION
The plugin was failing to find the original sourcemaps for some transpiled JavaScripts, and I managed to map to problem to how `resolve()` from the dependency `source-map-resolve` translates file paths containing spaces (and perhaps other special chars too).

After going trough `resolve()`, a path like `/dev/Test Folder/service.js.map` will be translated to `/dev/Test%20Folder/service.js.map`, which in turn will make `fs.readFile()` fail to locate the file, throwing an `ENOENT: no such file or directory, open...` error.

This was tested on Windows. I don't know if the problem occurs on other platforms, but it probably does, because it seams `fs.readFile()` (which is the read we're using on the plugin) doesn't work with url encoded paths.

I'm not sure if `source-map-resolve` is wrong. It handles URLs, after all, and receives the actual file reader as a parameter. Nevertheless, I contacted the author to see what he thinks about it.

Anyways, since this plugin is deliberately passing `fs.readfile` as the reader to `resolve()`, maybe it is its responsibility to make sure it's dealing with correct file system paths.  

Signed-off-by: Diego Vilar <diegovilar@gmail.com>