### PR TITLE
Fix: invalid exports for main target.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "dist/index.js",
-    "require": "dist/index.cjs"
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
   },
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
Hi there,

Since latest release I encounter an issue with the package in multiple projects. The following exception is thrown and complains about the path to `exports` specified in `package.json`. Apparently it should be a relative path.

![rollup-invalid-exports](https://user-images.githubusercontent.com/1299873/80796784-67c1be00-8ba0-11ea-964d-f2f76b088078.png)

Best,