### PR TITLE
fix: add support for Rollup version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dist"
   ],
   "dependencies": {
-    "@rollup/pluginutils": "^3.0.9",
+    "@rollup/pluginutils": "^5.0.2",
     "source-map-resolve": "^0.6.0"
   },
   "devDependencies": {
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "@types/node": ">=10.0.0",
-    "rollup": ">=0.31.2"
+    "rollup": "^1.20.0||^2.0.0||^3.0.0"
   },
   "peerDependenciesMeta": {
     "@types/node": {


### PR DESCRIPTION
This fixes incorrect peer deps

```
  +-- rollup-plugin-sourcemaps@0.6.3
  | +-- @rollup/pluginutils@3.1.0
  | | `-- rollup@3.5.1 deduped invalid: "^1.20.0||^2.0.0" from node_modules/rollup-plugin-sourcemaps/node_modules/@rollup/pluginutils
  | `-- rollup@3.5.1 deduped
```