### PR TITLE
Bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,23 +40,23 @@
     "dist"
   ],
   "dependencies": {
-    "@rollup/pluginutils": "^3.0.9",
+    "@rollup/pluginutils": "^5.0.2",
     "source-map-resolve": "^0.6.0"
   },
   "devDependencies": {
-    "@rollup/plugin-typescript": "6.0.0",
-    "@types/node": "^10.17.21",
-    "@typescript-eslint/eslint-plugin": "^4.0.0",
-    "@typescript-eslint/parser": "^4.0.0",
-    "eslint": "^7.1.0",
-    "eslint-config-prettier": "^6.9.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "jest": "^26.0.0",
-    "prettier": "^2.0.5",
-    "rimraf": "^3.0.0",
-    "rollup": "^2.7.5",
-    "ts-jest": "^26.0.0",
-    "typescript": "~4.0.0"
+    "@rollup/plugin-typescript": "10.0.1",
+    "@types/node": "^18.11.17",
+    "@typescript-eslint/eslint-plugin": "^5.46.1",
+    "@typescript-eslint/parser": "^5.46.1",
+    "eslint": "^8.30.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "jest": "^29.3.1",
+    "prettier": "^2.8.1",
+    "rimraf": "^3.0.2",
+    "rollup": "^3.7.5",
+    "ts-jest": "^29.0.3",
+    "typescript": "~4.9.4"
   },
   "peerDependencies": {
     "@types/node": ">=10.0.0",

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -99,11 +99,7 @@ describe('detects files with source maps', () => {
       sourceMap,
       inlineSourceMap,
       inlineSources,
-    }: {
-      sourceMap: boolean;
-      inlineSourceMap: boolean;
-      inlineSources: boolean;
-    }) => {
+    }: Record<string, boolean>) => {
       const { outputText, sourceMapText } = ts.transpileModule(inputText, {
         fileName: inputPath,
         compilerOptions: {


### PR DESCRIPTION
During a migration from rollup 2 to 3, I recently found this library to be a roadblock due to old dependencies (old pluginutils versions require rollup 1 or 2 as a peerDependency). This refreshes all dependencies to their latest, and makes sure the 9 tests still pass.