### PR TITLE
Support watching for source changes with Rollup 4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { resolve as resolvePath } from 'path';
 import { promisify } from 'util';
 import { Plugin, ExistingRawSourceMap } from 'rollup';
 import pluginUtils, { CreateFilter } from '@rollup/pluginutils';
@@ -32,7 +33,9 @@ export default function sourcemaps({
         return null;
       }
 
-      let code: string;
+      // Allow the original file to be watched
+      this.addWatchFile(resolvePath(id));
+
       try {
         code = (await promisifiedReadFile(id)).toString();
       } catch {


### PR DESCRIPTION
Plugins have to call `addWatchFile` now.

See https://github.com/2wce/rollup-plugin-sourcemaps2/issues/59.